### PR TITLE
doc(): add a global doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# eslint-tools
+M6 WEB's ESLint packages.
+
+## @m6web/eslint-config
+
+Eslint config from M6Web, see documentation [here](./packages/eslint-config/README.md).
+
+## @m6web/eslint-plugin
+
+Eslint and prettier package from M6Web, see documentation [here](./packages/eslint-plugin/README.md).


### PR DESCRIPTION
Add global documentation pointing to packages documentation.