### PR TITLE
Documentation improvements and extends-flow overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ M6 WEB's ESLint packages.
 
 Eslint config from M6Web, see documentation [here](./packages/eslint-config/README.md).
 
-## @m6web/eslint-plugin
+## @m6web/eslint-plugin-react
 
-Eslint and prettier package from M6Web, see documentation [here](./packages/eslint-plugin/README.md).
+Eslint and prettier package from M6Web, see documentation [here](./packages/eslint-plugin-react/README.md).
+
+## @m6web/eslint-plugin-vue
+
+Eslint and prettier package from M6Web, see documentation [here](./packages/eslint-plugin-vue/README.md).

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "format": "prettier-eslint --write 'packages/**/*.js'"
   },
   "devDependencies": {
-    "@m6web/eslint-config": "3.0.1",
     "lerna": "3.4.0"
   }
 }

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['airbnb'],
+  extends: ['airbnb-base'],
   env: {
     node: true,
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,9 +13,7 @@
   },
   "dependencies": {
     "eslint": "5.6.0",
-    "eslint-config-airbnb": "17.1.0",
-    "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
-    "eslint-plugin-react": "7.11.1"
+    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-plugin-import": "2.14.0"
   }
 }

--- a/packages/eslint-plugin-react/index.js
+++ b/packages/eslint-plugin-react/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   configs: {
     default: {
-      extends: ['@m6web', 'prettier', 'prettier/react'],
+      extends: ['airbnb', 'prettier', 'prettier/react', '@m6web'],
       plugins: ['react', 'prettier'],
       rules: {
         'prettier/prettier': [

--- a/packages/eslint-plugin-react/package.json
+++ b/packages/eslint-plugin-react/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@m6web/eslint-config": "^3.1.0",
     "eslint": "5.6.0",
+    "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "3.1.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.1.1",

--- a/packages/eslint-plugin-vue/README.md
+++ b/packages/eslint-plugin-vue/README.md
@@ -13,13 +13,13 @@ With that come some little changes from the default config of [eslint-config-air
 ## Setup
 
 ```shell
-npm install --dev @m6web/eslint-plugin
+npm install --dev @m6web/eslint-plugin-vue babel-eslint
 ```
 
 or
 
 ```shell
-yarn add --dev @m6web/eslint-plugin
+yarn add --dev @m6web/eslint-plugin-vue babel-eslint
 ```
 
 Then you need to add the plugin in the `.eslintrc` file of your project. For that create a `.eslintrc` and add the following lines:

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -16,11 +16,12 @@
     "eslint": "5.6.0",
     "eslint-config-prettier": "3.1.0",
     "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
     "eslint-plugin-prettier": "2.6.2",
-    "eslint-plugin-react": "7.11.1",
-    "eslint-plugin-vue": "^4.4.0",
+    "eslint-plugin-vue": "4.7.1",
     "prettier": "1.14.3",
     "prettier-eslint-cli": "4.7.1"
+  },
+  "peerDependencies": {
+    "babel-eslint": "10.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,7 +1823,7 @@ eslint-plugin-react@7.11.1:
     jsx-ast-utils "^2.0.1"
     prop-types "^15.6.2"
 
-eslint-plugin-vue@^4.4.0:
+eslint-plugin-vue@4.7.1:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-4.7.1.tgz#c829b9fc62582c1897b5a0b94afd44ecca511e63"
   integrity sha512-esETKhVMI7Vdli70Wt4bvAwnZBJeM0pxVX9Yb0wWKxdCJc2EADalVYK/q2FzMw8oKN0wPMdqVCKS8kmR89recA==


### PR DESCRIPTION
- react is not needed outside of the corresponding plugin  
  extends are changed so react rules are only applied where applicable
- the plugin vue doesn't work/provide sufficient documentation to use on a new project: babel-eslint doesn't work as a plugin dependency, eslint fails with the message  
  `  0:0  error  Parsing error: Cannot find module 'babel-eslint'`
  babel-eslint is added both as a peerDependency and on the installation documentation
- it is unnecessary to add `"@m6web/eslint-config"` as a root dependency (presumably to use in the `lint` command) because lerna actually fails and does the linking of child packages already