### PR TITLE
chore: upgrade node to at least version 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 18
           cache: 'yarn'
       - run: git config user.email "-" && git config user.name "🤖 Release Bot"
       - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "*.{js,json,md,yml}": [
       "prettier --write --ignore-unknown"
     ]
+  },
+  "engines": {
+    "node": ">=16"
   }
 }


### PR DESCRIPTION
In order to be able to update certain packages, we need to deprecate node version 12/14, which is no longer compatible with many packages.

node 20 added for October 2023 release (LTS)

Also part of this PR https://github.com/BedrockStreaming/eslint-tools/pull/103